### PR TITLE
Add resize-from-nearest-corner behavior and improve precision/smoothness

### DIFF
--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -1,6 +1,13 @@
 import AppKit
 import Foundation
 
+enum Corner {
+    case TopLeft
+    case TopRight
+    case BottomLeft
+    case BottomRight
+}
+
 final class Mover {
     var state: FlagState = .Ignore {
         didSet {
@@ -14,7 +21,7 @@ final class Mover {
     private var initialMousePosition: CGPoint?
     private var initialWindowPosition: CGPoint?
     private var initialWindowSize: CGSize?
-    private var closestCorner: Int?
+    private var closestCorner: Corner?
     private var window: AccessibilityElement?
 
     private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
@@ -43,38 +50,37 @@ final class Mover {
         }
     }
 
-    private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
+    private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Corner {
         if let size = window.size, let position = window.position {
             let xmid = position.x + size.width / 2
             let ymid = position.y + size.height / 2
             if mouse.x < xmid && mouse.y < ymid {
-                return 0  // top left
+                return .TopLeft
             } else if mouse.x >= xmid && mouse.y < ymid {
-                return 1  // top right
+                return .TopRight
             } else if mouse.x < xmid && mouse.y >= ymid {
-                return 2  // bottom left
+                return .BottomLeft
             } else {
-                return 3  // bottom right
+                return .BottomRight
             }
         }
-        return 3
+        return .BottomRight
     }
 
     private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
         if let initWinSize = self.initialWindowSize, let initWinPos = self.initialWindowPosition, let corner = self.closestCorner {
             switch corner {
-            case 0:
+            case .TopLeft:
                 window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
                 window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height - mouseDelta.y)
-            case 1:
+            case .TopRight:
                 window.position = CGPoint(x: initWinPos.x, y: initWinPos.y + mouseDelta.y)
                 window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height - mouseDelta.y)
-            case 2:
+            case .BottomLeft:
                 window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y)
                 window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height + mouseDelta.y)
-            case 3:
+            case .BottomRight:
                 window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height + mouseDelta.y)
-            default: break
             }
         }
     }

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -87,6 +87,7 @@ final class Mover {
 
     private func changed(state: FlagState) {
         self.removeMonitor()
+        self.resetState()
 
         switch state {
         case .Resize:
@@ -98,12 +99,16 @@ final class Mover {
                 self.mouseMoved(handler: self.moveWindow)
             }
         case .Ignore:
-            self.initialMousePosition = nil
-            self.initialWindowPosition = nil
-            self.initialWindowSize = nil
-            self.closestCorner = nil
-            self.window = nil
+            break
         }
+    }
+
+    private func resetState() {
+        self.initialMousePosition = nil
+        self.initialWindowPosition = nil
+        self.initialWindowSize = nil
+        self.closestCorner = nil
+        self.window = nil
     }
 
     private func removeMonitor() {

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -11,77 +11,77 @@ final class Mover {
     }
 
     private var monitor: Any?
-    private var lastMousePosition: CGPoint?
+    private var initialMousePosition: CGPoint?
+    private var initialWindowPosition: CGPoint?
+    private var initialWindowSize: CGSize?
+    private var closestCorner: Int?
     private var window: AccessibilityElement?
 
-    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint, _ corner: Int) -> Void) {
+    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
         let point = Mouse.currentPosition()
         if self.window == nil {
             self.window = AccessibilityElement.systemWideElement.element(at: point)?.window()
         }
-
         guard let window = self.window else {
             return
         }
 
-        let currentPid = NSRunningApplication.current.processIdentifier
-        if let pid = window.pid(), pid != currentPid {
-            NSRunningApplication(processIdentifier: pid)?.activate(options: .activateIgnoringOtherApps)
-        }
+        if self.initialMousePosition == nil {
+            self.initialMousePosition = point
+            self.initialWindowPosition = window.position
+            self.initialWindowSize = window.size
+            self.closestCorner = self.getClosestCorner(window: window, mouse: point)
 
-        window.bringToFront()
-        if let lastPosition = self.lastMousePosition {
-            let mouseDelta = CGPoint(x: point.x - lastPosition.x, y: point.y - lastPosition.y)
-            handler(window, mouseDelta, closestCorner(window: window, mouse: point))
+            let currentPid = NSRunningApplication.current.processIdentifier
+            if let pid = window.pid(), pid != currentPid {
+                NSRunningApplication(processIdentifier: pid)?.activate(options: .activateIgnoringOtherApps)
+            }
+            window.bringToFront()
+        } else if let initialMousePosition = self.initialMousePosition {
+            let mouseDelta = CGPoint(x: point.x - initialMousePosition.x, y: point.y - initialMousePosition.y)
+            handler(window, mouseDelta)
         }
-
-        self.lastMousePosition = point
     }
 
-    private func closestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
-        if let size = window.size {
-            if let position = window.position {
-                let xmid = position.x + size.width / 2
-                let ymid = position.y + size.height / 2
-                if mouse.x < xmid && mouse.y < ymid {
-                    return 0  // top left
-                } else if mouse.x >= xmid && mouse.y < ymid {
-                    return 1  // top right
-                } else if mouse.x < xmid && mouse.y >= ymid {
-                    return 2  // bottom left
-                } else {
-                    return 3  // bottom right
-                }
+    private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
+        if let size = window.size, let position = window.position {
+            let xmid = position.x + size.width / 2
+            let ymid = position.y + size.height / 2
+            if mouse.x < xmid && mouse.y < ymid {
+                return 0  // top left
+            } else if mouse.x >= xmid && mouse.y < ymid {
+                return 1  // top right
+            } else if mouse.x < xmid && mouse.y >= ymid {
+                return 2  // bottom left
+            } else {
+                return 3  // bottom right
             }
         }
         return 3
     }
 
-    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
-        if let size = window.size {
-            if let position = window.position {
-                switch corner {
-                case 0:
-                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
-                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height - mouseDelta.y)
-                case 1:
-                    window.position = CGPoint(x: position.x, y: position.y + mouseDelta.y)
-                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height - mouseDelta.y)
-                case 2:
-                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y)
-                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height + mouseDelta.y)
-                case 3:
-                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height + mouseDelta.y)
-                default: break
-                }
+    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+        if let initWinSize = self.initialWindowSize, let initWinPos = self.initialWindowPosition, let corner = self.closestCorner {
+            switch corner {
+            case 0:
+                window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
+                window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height - mouseDelta.y)
+            case 1:
+                window.position = CGPoint(x: initWinPos.x, y: initWinPos.y + mouseDelta.y)
+                window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height - mouseDelta.y)
+            case 2:
+                window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y)
+                window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height + mouseDelta.y)
+            case 3:
+                window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height + mouseDelta.y)
+            default: break
             }
         }
     }
 
-    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
-        if let position = window.position {
-            let newPosition = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
-            window.position = newPosition
+    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+    if let initWinPos = self.initialWindowPosition {
+            window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
         }
     }
 
@@ -98,7 +98,10 @@ final class Mover {
                 self.mouseMoved(handler: self.moveWindow)
             }
         case .Ignore:
-            self.lastMousePosition = nil
+            self.initialMousePosition = nil
+            self.initialWindowPosition = nil
+            self.initialWindowSize = nil
+            self.closestCorner = nil
             self.window = nil
         }
     }

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -14,7 +14,7 @@ final class Mover {
     private var lastMousePosition: CGPoint?
     private var window: AccessibilityElement?
 
-    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
+    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint, _ corner: Int) -> Void) {
         let point = Mouse.currentPosition()
         if self.window == nil {
             self.window = AccessibilityElement.systemWideElement.element(at: point)?.window()
@@ -31,23 +31,56 @@ final class Mover {
 
         window.bringToFront()
         if let lastPosition = self.lastMousePosition {
-            let mouseDelta = CGPoint(x: lastPosition.x - point.x, y: lastPosition.y - point.y)
-            handler(window, mouseDelta)
+            let mouseDelta = CGPoint(x: point.x - lastPosition.x, y: point.y - lastPosition.y)
+            handler(window, mouseDelta, closestCorner(window: window, mouse: point))
         }
 
         self.lastMousePosition = point
     }
 
-    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+    private func closestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
         if let size = window.size {
-            let newSize = CGSize(width: size.width - mouseDelta.x, height: size.height - mouseDelta.y)
-            window.size = newSize
+            if let position = window.position {
+                let xmid = position.x + size.width / 2
+                let ymid = position.y + size.height / 2
+                if mouse.x < xmid && mouse.y < ymid {
+                    return 0  // top left
+                } else if mouse.x >= xmid && mouse.y < ymid {
+                    return 1  // top right
+                } else if mouse.x < xmid && mouse.y >= ymid {
+                    return 2  // bottom left
+                } else {
+                    return 3  // bottom right
+                }
+            }
+        }
+        return 3
+    }
+
+    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
+        if let size = window.size {
+            if let position = window.position {
+                switch corner {
+                case 0:
+                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
+                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height - mouseDelta.y)
+                case 1:
+                    window.position = CGPoint(x: position.x, y: position.y + mouseDelta.y)
+                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height - mouseDelta.y)
+                case 2:
+                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y)
+                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height + mouseDelta.y)
+                case 3:
+                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height + mouseDelta.y)
+                default: break
+                }
+            }
         }
     }
 
-    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
         if let position = window.position {
-            let newPosition = CGPoint(x: position.x - mouseDelta.x, y: position.y - mouseDelta.y)
+            let newPosition = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
             window.position = newPosition
         }
     }


### PR DESCRIPTION
I haven't ever done OS X or Swift programming, so I'm sure things might be slightly wonky, feedback welcome.

I didn't add a config option for the nearest-corner resizing. It would be easy to add a conditional to `resizeWindow` and do the old behavior (same code as `corner==4`). But I don't really know how to add config options :).