### PR TITLE
Demo PR: restricts resize and move to main screen boundary

### DIFF
--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -1,6 +1,13 @@
 import AppKit
 import Foundation
 
+enum Corner {
+    case TopLeft
+    case TopRight
+    case BottomLeft
+    case BottomRight
+}
+
 final class Mover {
     var state: FlagState = .Ignore {
         didSet {
@@ -14,7 +21,7 @@ final class Mover {
     private var initialMousePosition: CGPoint?
     private var initialWindowPosition: CGPoint?
     private var initialWindowSize: CGSize?
-    private var closestCorner: Int?
+    private var closestCorner: Corner?
     private var window: AccessibilityElement?
 
     private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
@@ -43,38 +50,37 @@ final class Mover {
         }
     }
 
-    private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
+    private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Corner {
         if let size = window.size, let position = window.position {
             let xmid = position.x + size.width / 2
             let ymid = position.y + size.height / 2
             if mouse.x < xmid && mouse.y < ymid {
-                return 0  // top left
+                return .TopLeft
             } else if mouse.x >= xmid && mouse.y < ymid {
-                return 1  // top right
+                return .TopRight
             } else if mouse.x < xmid && mouse.y >= ymid {
-                return 2  // bottom left
+                return .BottomLeft
             } else {
-                return 3  // bottom right
+                return .BottomRight
             }
         }
-        return 3
+        return .BottomRight
     }
 
     private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
         if let initWinSize = self.initialWindowSize, let initWinPos = self.initialWindowPosition, let corner = self.closestCorner {
             switch corner {
-            case 0:
+            case .TopLeft:
                 window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
                 window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height - mouseDelta.y)
-            case 1:
+            case .TopRight:
                 window.position = CGPoint(x: initWinPos.x, y: initWinPos.y + mouseDelta.y)
                 window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height - mouseDelta.y)
-            case 2:
+            case .BottomLeft:
                 window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y)
                 window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height + mouseDelta.y)
-            case 3:
+            case .BottomRight:
                 window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height + mouseDelta.y)
-            default: break
             }
         }
     }

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -87,6 +87,7 @@ final class Mover {
 
     private func changed(state: FlagState) {
         self.removeMonitor()
+        self.resetState()
 
         switch state {
         case .Resize:
@@ -98,12 +99,16 @@ final class Mover {
                 self.mouseMoved(handler: self.moveWindow)
             }
         case .Ignore:
-            self.initialMousePosition = nil
-            self.initialWindowPosition = nil
-            self.initialWindowSize = nil
-            self.closestCorner = nil
-            self.window = nil
+            break
         }
+    }
+
+    private func resetState() {
+        self.initialMousePosition = nil
+        self.initialWindowPosition = nil
+        self.initialWindowSize = nil
+        self.closestCorner = nil
+        self.window = nil
     }
 
     private func removeMonitor() {

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -11,77 +11,77 @@ final class Mover {
     }
 
     private var monitor: Any?
-    private var lastMousePosition: CGPoint?
+    private var initialMousePosition: CGPoint?
+    private var initialWindowPosition: CGPoint?
+    private var initialWindowSize: CGSize?
+    private var closestCorner: Int?
     private var window: AccessibilityElement?
 
-    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint, _ corner: Int) -> Void) {
+    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
         let point = Mouse.currentPosition()
         if self.window == nil {
             self.window = AccessibilityElement.systemWideElement.element(at: point)?.window()
         }
-
         guard let window = self.window else {
             return
         }
 
-        let currentPid = NSRunningApplication.current.processIdentifier
-        if let pid = window.pid(), pid != currentPid {
-            NSRunningApplication(processIdentifier: pid)?.activate(options: .activateIgnoringOtherApps)
-        }
+        if self.initialMousePosition == nil {
+            self.initialMousePosition = point
+            self.initialWindowPosition = window.position
+            self.initialWindowSize = window.size
+            self.closestCorner = self.getClosestCorner(window: window, mouse: point)
 
-        window.bringToFront()
-        if let lastPosition = self.lastMousePosition {
-            let mouseDelta = CGPoint(x: point.x - lastPosition.x, y: point.y - lastPosition.y)
-            handler(window, mouseDelta, closestCorner(window: window, mouse: point))
+            let currentPid = NSRunningApplication.current.processIdentifier
+            if let pid = window.pid(), pid != currentPid {
+                NSRunningApplication(processIdentifier: pid)?.activate(options: .activateIgnoringOtherApps)
+            }
+            window.bringToFront()
+        } else if let initialMousePosition = self.initialMousePosition {
+            let mouseDelta = CGPoint(x: point.x - initialMousePosition.x, y: point.y - initialMousePosition.y)
+            handler(window, mouseDelta)
         }
-
-        self.lastMousePosition = point
     }
 
-    private func closestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
-        if let size = window.size {
-            if let position = window.position {
-                let xmid = position.x + size.width / 2
-                let ymid = position.y + size.height / 2
-                if mouse.x < xmid && mouse.y < ymid {
-                    return 0  // top left
-                } else if mouse.x >= xmid && mouse.y < ymid {
-                    return 1  // top right
-                } else if mouse.x < xmid && mouse.y >= ymid {
-                    return 2  // bottom left
-                } else {
-                    return 3  // bottom right
-                }
+    private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
+        if let size = window.size, let position = window.position {
+            let xmid = position.x + size.width / 2
+            let ymid = position.y + size.height / 2
+            if mouse.x < xmid && mouse.y < ymid {
+                return 0  // top left
+            } else if mouse.x >= xmid && mouse.y < ymid {
+                return 1  // top right
+            } else if mouse.x < xmid && mouse.y >= ymid {
+                return 2  // bottom left
+            } else {
+                return 3  // bottom right
             }
         }
         return 3
     }
 
-    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
-        if let size = window.size {
-            if let position = window.position {
-                switch corner {
-                case 0:
-                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
-                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height - mouseDelta.y)
-                case 1:
-                    window.position = CGPoint(x: position.x, y: position.y + mouseDelta.y)
-                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height - mouseDelta.y)
-                case 2:
-                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y)
-                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height + mouseDelta.y)
-                case 3:
-                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height + mouseDelta.y)
-                default: break
-                }
+    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+        if let initWinSize = self.initialWindowSize, let initWinPos = self.initialWindowPosition, let corner = self.closestCorner {
+            switch corner {
+            case 0:
+                window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
+                window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height - mouseDelta.y)
+            case 1:
+                window.position = CGPoint(x: initWinPos.x, y: initWinPos.y + mouseDelta.y)
+                window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height - mouseDelta.y)
+            case 2:
+                window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y)
+                window.size = CGSize(width: initWinSize.width - mouseDelta.x, height: initWinSize.height + mouseDelta.y)
+            case 3:
+                window.size = CGSize(width: initWinSize.width + mouseDelta.x, height: initWinSize.height + mouseDelta.y)
+            default: break
             }
         }
     }
 
-    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
-        if let position = window.position {
-            let newPosition = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
-            window.position = newPosition
+    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+    if let initWinPos = self.initialWindowPosition {
+            window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
         }
     }
 
@@ -98,7 +98,10 @@ final class Mover {
                 self.mouseMoved(handler: self.moveWindow)
             }
         case .Ignore:
-            self.lastMousePosition = nil
+            self.initialMousePosition = nil
+            self.initialWindowPosition = nil
+            self.initialWindowSize = nil
+            self.closestCorner = nil
             self.window = nil
         }
     }

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -14,7 +14,7 @@ final class Mover {
     private var lastMousePosition: CGPoint?
     private var window: AccessibilityElement?
 
-    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
+    private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint, _ corner: Int) -> Void) {
         let point = Mouse.currentPosition()
         if self.window == nil {
             self.window = AccessibilityElement.systemWideElement.element(at: point)?.window()
@@ -31,23 +31,56 @@ final class Mover {
 
         window.bringToFront()
         if let lastPosition = self.lastMousePosition {
-            let mouseDelta = CGPoint(x: lastPosition.x - point.x, y: lastPosition.y - point.y)
-            handler(window, mouseDelta)
+            let mouseDelta = CGPoint(x: point.x - lastPosition.x, y: point.y - lastPosition.y)
+            handler(window, mouseDelta, closestCorner(window: window, mouse: point))
         }
 
         self.lastMousePosition = point
     }
 
-    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+    private func closestCorner(window: AccessibilityElement, mouse: CGPoint) -> Int {
         if let size = window.size {
-            let newSize = CGSize(width: size.width - mouseDelta.x, height: size.height - mouseDelta.y)
-            window.size = newSize
+            if let position = window.position {
+                let xmid = position.x + size.width / 2
+                let ymid = position.y + size.height / 2
+                if mouse.x < xmid && mouse.y < ymid {
+                    return 0  // top left
+                } else if mouse.x >= xmid && mouse.y < ymid {
+                    return 1  // top right
+                } else if mouse.x < xmid && mouse.y >= ymid {
+                    return 2  // bottom left
+                } else {
+                    return 3  // bottom right
+                }
+            }
+        }
+        return 3
+    }
+
+    private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
+        if let size = window.size {
+            if let position = window.position {
+                switch corner {
+                case 0:
+                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
+                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height - mouseDelta.y)
+                case 1:
+                    window.position = CGPoint(x: position.x, y: position.y + mouseDelta.y)
+                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height - mouseDelta.y)
+                case 2:
+                    window.position = CGPoint(x: position.x + mouseDelta.x, y: position.y)
+                    window.size = CGSize(width: size.width - mouseDelta.x, height: size.height + mouseDelta.y)
+                case 3:
+                    window.size = CGSize(width: size.width + mouseDelta.x, height: size.height + mouseDelta.y)
+                default: break
+                }
+            }
         }
     }
 
-    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
+    private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint, corner: Int) {
         if let position = window.position {
-            let newPosition = CGPoint(x: position.x - mouseDelta.x, y: position.y - mouseDelta.y)
+            let newPosition = CGPoint(x: position.x + mouseDelta.x, y: position.y + mouseDelta.y)
             window.position = newPosition
         }
     }

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -106,8 +106,12 @@ final class Mover {
     }
 
     private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
-        if let initWinPos = self.initialWindowPosition {
-            window.position = CGPoint(x: initWinPos.x + mouseDelta.x, y: initWinPos.y + mouseDelta.y)
+        if let initWinPos = self.initialWindowPosition, let initWinSize = self.initialWindowSize, let frame = self.frame {
+            let mdx = min(max(mouseDelta.x, frame.minX - initWinPos.x),
+                          frame.maxX - (initWinPos.x + initWinSize.width))
+            let mdy = min(max(mouseDelta.y, frame.minY - initWinPos.y),
+                          frame.maxY - (initWinPos.y + initWinSize.height))
+            window.position = CGPoint(x: initWinPos.x + mdx, y: initWinPos.y + mdy)
         }
     }
 

--- a/ModMove/Mover.swift
+++ b/ModMove/Mover.swift
@@ -24,41 +24,67 @@ final class Mover {
     private var closestCorner: Corner?
     private var window: AccessibilityElement?
     private var frame: NSRect?
+    private var scaleFactor: CGFloat?
+
+    private var prevMousePosition: CGPoint?
+    private var prevDate: Date = Date()
+    // Mouse speed is in pixels/second.
+    private var mouseSpeed: CGFloat = 0
+    private let FAST_MOUSE_SPEED_THRESHOLD: CGFloat = 1000
+    // Weight given to latest mouse speed for averaging.
+    private let MOUSE_SPEED_WEIGHT: CGFloat = 0.1
 
     private func mouseMoved(handler: (_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Void) {
-        let point = Mouse.currentPosition()
+        let curMousePos = Mouse.currentPosition()
         if self.window == nil {
-            self.window = AccessibilityElement.systemWideElement.element(at: point)?.window()
+            self.window = AccessibilityElement.systemWideElement.element(at: curMousePos)?.window()
         }
         guard let window = self.window else {
             return
         }
 
         if self.initialMousePosition == nil {
-            self.initialMousePosition = point
+            self.prevMousePosition = curMousePos
+            self.initialMousePosition = curMousePos
             self.initialWindowPosition = window.position
             self.initialWindowSize = window.size
-            self.closestCorner = self.getClosestCorner(window: window, mouse: point)
-            self.frame = getUsableScreen()
+            self.closestCorner = self.getClosestCorner(window: window, mouse: curMousePos)
+            (self.frame, self.scaleFactor) = getUsableScreen()
 
             let currentPid = NSRunningApplication.current.processIdentifier
             if let pid = window.pid(), pid != currentPid {
                 NSRunningApplication(processIdentifier: pid)?.activate(options: .activateIgnoringOtherApps)
             }
             window.bringToFront()
-        } else if let initialMousePosition = self.initialMousePosition {
-            let mouseDelta = CGPoint(x: point.x - initialMousePosition.x, y: point.y - initialMousePosition.y)
+        } else if let initMousePos = self.initialMousePosition {
+            self.trackMouseSpeed(curMousePos: curMousePos)
+            let mouseDelta = CGPoint(x: curMousePos.x - initMousePos.x, y: curMousePos.y - initMousePos.y)
             handler(window, mouseDelta)
         }
     }
 
-    private func getUsableScreen() -> NSRect? {
-        if var visible = NSScreen.main?.visibleFrame, let full = NSScreen.main?.frame {
+    private func trackMouseSpeed(curMousePos: CGPoint) {
+        if let prevMousePos = self.prevMousePosition, let scale = self.scaleFactor {
+            let mouseDist: CGFloat = sqrt(
+                pow((curMousePos.x - prevMousePos.x) / scale, 2)
+                + pow((curMousePos.y - prevMousePos.y) / scale, 2))
+            let now = Date()
+            let timeDiff: CGFloat = CGFloat(now.timeIntervalSince(prevDate))
+            let latestMouseSpeed = mouseDist / timeDiff
+            self.mouseSpeed = latestMouseSpeed * MOUSE_SPEED_WEIGHT + self.mouseSpeed * (1 - MOUSE_SPEED_WEIGHT)
+            self.prevMousePosition = curMousePos
+            self.prevDate = now
+            // NSLog("timeD: %.3f\tmouseD: %.1f\tmouseSpeed: %.1f", timeDiff, mouseDist, scale, self.mouseSpeed)
+        }
+    }
+
+    private func getUsableScreen() -> (NSRect, CGFloat) {
+        if var visible = NSScreen.main?.visibleFrame, let full = NSScreen.main?.frame, let scale = NSScreen.main?.backingScaleFactor {
             // For some reason, visibleFrame still has minY = 0 even though the menubar is there?
             visible.origin.y = full.size.height - visible.size.height
-            return visible
+            return (visible, scale)
         }
-        return NSRect.zero
+        return (NSRect.zero, 1)
     }
 
     private func getClosestCorner(window: AccessibilityElement, mouse: CGPoint) -> Corner {
@@ -81,25 +107,35 @@ final class Mover {
     private func resizeWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
         if let initWinSize = self.initialWindowSize, let initWinPos = self.initialWindowPosition,
             let corner = self.closestCorner, let frame = self.frame {
+            var mdx = mouseDelta.x
+            var mdy = mouseDelta.y
             switch corner {
             case .TopLeft:
-                let mdx = max(mouseDelta.x, frame.minX - initWinPos.x)
-                let mdy = max(mouseDelta.y, frame.minY - initWinPos.y)
+                if shouldConstrainMouseDelta(window, mouseDelta) {
+                    mdx = max(mouseDelta.x, frame.minX - initWinPos.x)
+                    mdy = max(mouseDelta.y, frame.minY - initWinPos.y)
+                }
                 window.position =  CGPoint(x: initWinPos.x + mdx, y: initWinPos.y + mdy)
                 window.size = CGSize(width: initWinSize.width - mdx, height: initWinSize.height - mdy)
             case .TopRight:
-                let mdx = min(mouseDelta.x, frame.maxX - (initWinPos.x + initWinSize.width))
-                let mdy = max(mouseDelta.y, frame.minY - initWinPos.y)
+                if shouldConstrainMouseDelta(window, mouseDelta) {
+                    mdx = min(mouseDelta.x, frame.maxX - (initWinPos.x + initWinSize.width))
+                    mdy = max(mouseDelta.y, frame.minY - initWinPos.y)
+                }
                 window.position = CGPoint(x: initWinPos.x, y: initWinPos.y + mdy)
                 window.size = CGSize(width: initWinSize.width + mdx, height: initWinSize.height - mdy )
             case .BottomLeft:
-                let mdx = max(mouseDelta.x, frame.minX - initWinPos.x)
-                let mdy = min(mouseDelta.y, frame.maxY - (initWinPos.y + initWinSize.height))
+                if shouldConstrainMouseDelta(window, mouseDelta) {
+                    mdx = max(mouseDelta.x, frame.minX - initWinPos.x)
+                    mdy = min(mouseDelta.y, frame.maxY - (initWinPos.y + initWinSize.height))
+                }
                 window.position = CGPoint(x: initWinPos.x + mdx, y: initWinPos.y)
                 window.size = CGSize(width: initWinSize.width - mdx, height: initWinSize.height + mdy)
             case .BottomRight:
-                let mdx = min(mouseDelta.x, frame.maxX - (initWinPos.x + initWinSize.width))
-                let mdy = min(mouseDelta.y, frame.maxY - (initWinPos.y + initWinSize.height))
+                if shouldConstrainMouseDelta(window, mouseDelta) {
+                    mdx = min(mouseDelta.x, frame.maxX - (initWinPos.x + initWinSize.width))
+                    mdy = min(mouseDelta.y, frame.maxY - (initWinPos.y + initWinSize.height))
+                }
                 window.size = CGSize(width: initWinSize.width + mdx, height: initWinSize.height + mdy)
             }
         }
@@ -107,12 +143,31 @@ final class Mover {
 
     private func moveWindow(window: AccessibilityElement, mouseDelta: CGPoint) {
         if let initWinPos = self.initialWindowPosition, let initWinSize = self.initialWindowSize, let frame = self.frame {
-            let mdx = min(max(mouseDelta.x, frame.minX - initWinPos.x),
+            var mdx = mouseDelta.x
+            var mdy = mouseDelta.y
+            if shouldConstrainMouseDelta(window, mouseDelta) {
+                mdx = min(max(mouseDelta.x, frame.minX - initWinPos.x),
                           frame.maxX - (initWinPos.x + initWinSize.width))
-            let mdy = min(max(mouseDelta.y, frame.minY - initWinPos.y),
+                mdy = min(max(mouseDelta.y, frame.minY - initWinPos.y),
                           frame.maxY - (initWinPos.y + initWinSize.height))
+            }
             window.position = CGPoint(x: initWinPos.x + mdx, y: initWinPos.y + mdy)
         }
+    }
+
+    private func shouldConstrainMouseDelta(_ window: AccessibilityElement, _ mouseDelta: CGPoint) -> Bool {
+        // Slow moves get constrained. But once a window is out of the frame, we don't constrain it anymore.
+        if let frame = self.frame {
+            return self.mouseSpeed < FAST_MOUSE_SPEED_THRESHOLD && windowInsideFrame(window, frame)
+        }
+        return false
+    }
+
+    private func windowInsideFrame(_ window: AccessibilityElement, _ frame: CGRect) -> Bool {
+        if let pos = window.position, let size = window.size {
+            return frame.contains(NSMakeRect(pos.x, pos.y, size.width, size.height))
+        }
+        return true
     }
 
     private func changed(state: FlagState) {


### PR DESCRIPTION
Based on https://github.com/rxhanson/ModMove/pull/1
Adds "sticky edge" move and resize restrictions to the current screen: slow movements are constrained to the current screen boundaries, fast movements aren't. Doesn't handle multiple screens.